### PR TITLE
major version bump

### DIFF
--- a/crdt-event-fold.cabal
+++ b/crdt-event-fold.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                crdt-event-fold
-version:             0.1.0.0
+version:             1.0.0.0
 synopsis:            Garbage collected event folding CRDT.
 description:         Garbage collected event folding CRDT.
 homepage:            https://github.com/owensmurray/crdt-event-fold


### PR DESCRIPTION
Bumped the "big" major version number. We had some backward compatibility
changes that required a major bump, but we elected to change the "big"
version because that better reflects the maturity of the library. The
only reason the previous version was 0.1.0.0 was because this is newly
open-sourced. But the private library from which it is derived was at
4.4.0.0 when we decided to open source it.