### PR TITLE
bug: Fix `disassociate`. ...

### DIFF
--- a/crdt-event-fold.cabal
+++ b/crdt-event-fold.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                crdt-event-fold
-version:             1.1.0.0
+version:             1.2.0.0
 synopsis:            Garbage collected event folding CRDT.
 description:         Garbage collected event folding CRDT. Consistently
                      apply arbitrary operations to replicated data.

--- a/src/Data/CRDT/EventFold.hs
+++ b/src/Data/CRDT/EventFold.hs
@@ -705,14 +705,14 @@ participate self peer (EventFold ef) =
       let
         (ef2, outputs1) =
           acknowledge
-          self
-          ef {
-            psEvents =
-              Map.insert
-                eid
-                (Identity (Join peer), mempty)
-                (psEvents ef)
-          }
+            self
+            ef {
+              psEvents =
+                Map.insert
+                  eid
+                  (Identity (Join peer), mempty)
+                  (psEvents ef)
+            }
         (ef3, outputs2) = acknowledge peer ef2
       in
         UpdateResult {

--- a/src/Data/CRDT/EventFold.hs
+++ b/src/Data/CRDT/EventFold.hs
@@ -691,15 +691,12 @@ ackErr p ef =
   'EventId' is so that you can use it to tell when the participation
   event has reached the infimum. See also: 'infimumId'
 -}
-participate :: (Ord p, Event e)
+participate :: forall o p e. (Ord p, Event e)
   => p {- ^ The local participant. -}
   -> p {- ^ The participant being added. -}
   -> EventFold o p e
   -> (EventId p, UpdateResult o p e)
 participate self peer (EventFold ef) =
-  let
-    eid = nextId self ef
-  in
     (
       eid,
       let
@@ -725,6 +722,9 @@ participate self peer (EventFold ef) =
           urNeedsPropagation = True
         }
     )
+  where
+    eid :: EventId p
+    eid = nextId self ef
 
 
 {- |

--- a/test/test.hs
+++ b/test/test.hs
@@ -11,8 +11,8 @@ module Main (
 
 import Data.CRDT.EventFold (Event(Output, State, apply),
   EventResult(Pure), UpdateResult(urEventFold, urNeedsPropagation,
-  urOutputs), EventFold, diffMerge, divergent, event, events, fullMerge,
-  infimumValue, new, participate)
+  urOutputs), EventFold, diffMerge, disassociate, divergent, event,
+  events, fullMerge, infimumValue, new, participate)
 import Test.Hspec (describe, hspec, it, shouldBe, shouldNotBe)
 
 
@@ -196,6 +196,10 @@ main = hspec $
       show (divergent a) `shouldBe` "fromList [('b',Eid 4 'b'),('c',Eid 4 'a')]"
       show (divergent b) `shouldBe` "fromList [('a',Eid 2 'a')]"
       show (divergent c) `shouldBe` "fromList [('b',Eid 2 'a')]"
+
+      do {- A world where c leaves.  -}
+        let (_eid, r) = disassociate 'c' c
+        show (urEventFold r) `shouldBe` "EventFold {unEventFold = EventFoldF {psOrigin = 0, psInfimum = Infimum {eventId = Eid 2 'a', participants = fromList \"ab\", stateValue = -3}, psEvents = fromList [(Eid 3 'a',(Identity (Event Inc),fromList \"ac\")),(Eid 4 'a',(Identity (Join 'c'),fromList \"ac\")),(Eid 5 'c',(Identity (UnJoin 'c'),fromList \"c\"))]}}"
 
       {- | 'a' sends update to 'b'.  -}
       let Right r = diffMerge 'b' b (events 'b' a)


### PR DESCRIPTION
So that it will auto-acknowledge (which is the only way for a peer to
ack its own Unjoin).

This also required removing the distinction between self and the
unjoining peer.