### PR TITLE
feat: Don't automatically ack participation. ...

### DIFF
--- a/crdt-event-fold.cabal
+++ b/crdt-event-fold.cabal
@@ -30,6 +30,7 @@ library
     containers         >= 0.6.2.1 && < 0.7,
     data-default-class >= 0.1.2.0 && < 0.2,
     data-dword         >= 0.3.2   && < 0.4,
+    exceptions         >= 0.10.4  && < 0.11,
     monad-logger       >= 0.3.35  && < 0.4,
     mtl                >= 2.2.2   && < 2.3,
     transformers       >= 0.5.6.2 && < 0.6

--- a/crdt-event-fold.cabal
+++ b/crdt-event-fold.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                crdt-event-fold
-version:             1.4.0.0
+version:             1.5.0.0
 synopsis:            Garbage collected event folding CRDT.
 description:         Garbage collected event folding CRDT. Consistently
                      apply arbitrary operations to replicated data.

--- a/src/Data/CRDT/EventFold/Monad.hs
+++ b/src/Data/CRDT/EventFold/Monad.hs
@@ -42,14 +42,10 @@ class MonadUpdateEF o p e m | m -> o p e where
   event :: e -> m (Output e, EventId p)
 
   {- | Perform a full merge. See 'EF.fullMerge'. -}
-  fullMerge
-    :: EventFold o p e
-    -> m (Either (MergeError o p e) ())
+  fullMerge :: EventFold o p e -> m (Either (MergeError o p e) ())
 
   {- | Perform a diff merge. See 'EF.diffMerge'. -}
-  diffMerge
-    :: Diff o p e
-    -> m (Either (MergeError o p e) ())
+  diffMerge :: Diff o p e -> m (Either (MergeError o p e) ())
 
   {- | Allow a new participant to join in the cluster. See 'EF.participate'. -}
   participate :: p -> m (EventId p)

--- a/src/Data/CRDT/EventFold/Monad.hs
+++ b/src/Data/CRDT/EventFold/Monad.hs
@@ -16,6 +16,7 @@ module Data.CRDT.EventFold.Monad (
 ) where
 
 
+import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Logger (MonadLogger, MonadLoggerIO)
 import Control.Monad.Reader (MonadReader(ask), ReaderT(runReaderT))
@@ -83,6 +84,7 @@ newtype EventFoldT o p e m a = EventFoldT {
     , MonadIO
     , MonadLogger
     , MonadLoggerIO
+    , MonadThrow
     )
 instance MonadTrans (EventFoldT o p e) where
   lift = EventFoldT . lift . lift


### PR DESCRIPTION
Newly new participation in an object should not be auto acknowledged
by the joining participant. This enables the possibility of the new
participant obtaining a copy of the object asynchronously via a side
channel or by parallel construction which is guaranteed correct via some
other mechanism.