### PR TITLE
no-op: Fix documentation. ...

### DIFF
--- a/crdt-event-fold.cabal
+++ b/crdt-event-fold.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                crdt-event-fold
-version:             1.8.0.1
+version:             1.8.0.2
 synopsis:            Garbage collected event folding CRDT.
 description:         Garbage collected event folding CRDT. Consistently
                      apply arbitrary operations to replicated data.

--- a/src/Data/CRDT/EventFold/Monad.hs
+++ b/src/Data/CRDT/EventFold/Monad.hs
@@ -41,19 +41,19 @@ import qualified Data.CRDT.EventFold as EF
   - Whether the 'EventFold' needs to be propagated to other participants.
 -}
 class MonadUpdateEF o p e m | m -> o p e where
-  {- | Apply an event. See 'EF.event'. -}
+  {- | Apply an event. See 'Data.CRDT.EventFold.event'. -}
   event :: e -> m (Output e, EventId p)
 
-  {- | Perform a full merge. See 'EF.fullMerge'. -}
+  {- | Perform a full merge. See 'Data.CRDT.EventFold.fullMerge'. -}
   fullMerge :: EventFold o p e -> m (Either (MergeError o p e) ())
 
-  {- | Perform a diff merge. See 'EF.diffMerge'. -}
+  {- | Perform a diff merge. See 'Data.CRDT.EventFold.diffMerge'. -}
   diffMerge :: Diff o p e -> m (Either (MergeError o p e) ())
 
-  {- | Allow a new participant to join in the cluster. See 'EF.participate'. -}
+  {- | Allow a new participant to join in the cluster. See 'Data.CRDT.EventFold.participate'. -}
   participate :: p -> m (EventId p)
 
-  {- | Remove a peer from participation. See 'EF.disassociate'. -}
+  {- | Remove a peer from participation. See 'Data.CRDT.EventFold.disassociate'. -}
   disassociate :: p -> m (EventId p)
 
   {- | Get the outstanding update results. -}


### PR DESCRIPTION
This commit fixes the haddock documentation in `Data.CRDT.EventFold.Monad`
by correcting the links into the main module. I had previously thought
that haddock was smart enough to understand aliased qualified module
imports, but it is not. You have to use the fully qualified "true"
name of the module.